### PR TITLE
Use CMAKE_BUILD_TYPE environment variable to set build type

### DIFF
--- a/build/build_unix.sh
+++ b/build/build_unix.sh
@@ -33,7 +33,13 @@ if [[ "${ARCH_TAG}" ]]; then
     cmake_param="-DARCH_TAG=${ARCH_TAG} ${cmake_param}"
 fi
 
-cmake_param="-DCMAKE_BUILD_TYPE=Release ${cmake_param}"
+if [[ -z "${CMAKE_BUILD_TYPE}" ]]; then
+    CMAKE_BUILD_TYPE=Release
+else
+    echo "Using CMAKE_BUILD_TYPE from environment: ${CMAKE_BUILD_TYPE}"
+fi
+cmake_param="-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${cmake_param}"
+
 if [[ "$shared" == "1" ]]; then
     cmake_param="${cmake_param} -DMAKE_SHARED=1"
 fi


### PR DESCRIPTION
Currently, the inno-lidar-sdk always builds in Release mode by default. This limits flexibility for developers who may want to build in other configurations such as Debug or RelWithDebInfo.

This merge introduces a change to the build_unix.sh script that allows users to specify the desired build type via an environment variable. If the variable is not set, it will default to Release, preserving current behavior.